### PR TITLE
Add descriptors

### DIFF
--- a/qble.pri
+++ b/qble.pri
@@ -5,6 +5,7 @@ HEADERS += \
     $$PWD/qbledevice.h \
     $$PWD/qbleservice.h \
     $$PWD/qblecharacteristic.h \
+    $$PWD/qbledescriptor.h \
     $$PWD/bluezadapter.h
 
 SOURCES += \
@@ -12,5 +13,6 @@ SOURCES += \
     $$PWD/qbledevice.cpp \
     $$PWD/qbleservice.cpp \
     $$PWD/qblecharacteristic.cpp \
+    $$PWD/qbledescriptor.cpp \
     $$PWD/bluezadapter.cpp
 

--- a/qblecharacteristic.cpp
+++ b/qblecharacteristic.cpp
@@ -1,15 +1,19 @@
 #include "qblecharacteristic.h"
+#include <QtXml/QtXml>
+
 
 QBLECharacteristic::QBLECharacteristic(const QString &path, QObject *parent) : QObject(parent)
 {
     m_characteristicInterface = new QDBusInterface("org.bluez", path, "org.bluez.GattCharacteristic1", QDBusConnection::systemBus());
 
+    m_path = path;
     m_uuid = m_characteristicInterface->property("UUID").toString();
 
     QStringList argumentMatch;
     argumentMatch << "org.bluez.GattCharacteristic1";
     QDBusConnection::systemBus().connect("org.bluez", path, "org.freedesktop.DBus.Properties","PropertiesChanged", argumentMatch, QString(),
                             this, SLOT(onPropertiesChanged(QString, QVariantMap, QStringList)));
+    introspect();
 }
 
 void QBLECharacteristic::onPropertiesChanged(const QString &interface, const QVariantMap &map, const QStringList &list)
@@ -74,4 +78,36 @@ void QBLECharacteristic::stopNotify() const
 QByteArray QBLECharacteristic::value() const
 {
     return m_value;
+}
+
+
+void QBLECharacteristic::introspect()
+{
+    QDBusInterface miIntro("org.bluez", m_path, "org.freedesktop.DBus.Introspectable", QDBusConnection::systemBus(), 0);
+    QDBusReply<QString> xml = miIntro.call("Introspect");
+    QDomDocument doc;
+    doc.setContent(xml.value());
+
+    QDomNodeList nodes = doc.elementsByTagName("node");
+
+
+    for (int x = 0; x < nodes.count(); x++)
+    {
+        QDomElement node = nodes.at(x).toElement();
+        QString nodeName = node.attribute("name");
+
+        if (nodeName.startsWith("desc")) {
+            QString path = m_path + "/" + nodeName;
+            QDBusInterface descInterface("org.bluez", path, "org.bluez.GattDescriptor1", QDBusConnection::systemBus(), 0);
+                m_descriptorMap[descInterface.property("UUID").toString()] = new QBLEDescriptor(path, this);
+        }
+    }
+
+    qDebug() << Q_FUNC_INFO << "descriptors" << m_descriptorMap.keys();
+
+}
+
+QBLEDescriptor *QBLECharacteristic::descriptor(const QString &c) const
+{
+    return m_descriptorMap.value(c, nullptr);
 }

--- a/qblecharacteristic.h
+++ b/qblecharacteristic.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QVariantMap>
 #include <QtDBus>
+#include "qbledescriptor.h"
 
 class QBLECharacteristic : public QObject
 {
@@ -23,13 +24,22 @@ public:
     Q_SIGNAL void characteristicChanged(const QString &characterisitc, const QByteArray &value);
     Q_SIGNAL void characteristicRead(const QString &characterisitc, const QByteArray &value);
 
+    QBLEDescriptor *descriptor(const QString &c) const;
+
 private:
+    QString m_path;
     QString m_uuid;
     QByteArray m_value; //buffered value;
     QDBusInterface *m_characteristicInterface;
 
     Q_SLOT void onPropertiesChanged(const QString &interface, const QVariantMap &map, const QStringList &list);
     Q_SLOT void readFinished(QDBusPendingCallWatcher *call);
+
+
+    QMap<QString, QBLEDescriptor*> m_descriptorMap;
+
+    void introspect();
+
 };
 
 #endif // QBLECHARACTERISTIC_H

--- a/qbledescriptor.cpp
+++ b/qbledescriptor.cpp
@@ -1,0 +1,23 @@
+#include "qbledescriptor.h"
+
+QBLEDescriptor::QBLEDescriptor(const QString &path, QObject *parent) : QObject(parent)
+{
+    m_descriptorInterface = new QDBusInterface("org.bluez", path, "org.bluez.GattDescriptor1", QDBusConnection::systemBus());
+    m_uuid = m_descriptorInterface->property("UUID").toString();
+
+//    QStringList argumentMatch;
+//    argumentMatch << "org.bluez.GattDescriptor1";
+//    QDBusConnection::systemBus().connect("org.bluez", path, "org.freedesktop.DBus.Properties","PropertiesChanged", argumentMatch, QString(),
+//                            this, SLOT(onPropertiesChanged(QString, QVariantMap, QStringList)));
+}
+
+void QBLEDescriptor::writeValue(const QByteArray &val) const
+{
+    m_descriptorInterface->call("WriteValue", val, QVariantMap());
+}
+
+void QBLEDescriptor::writeAsync(const QByteArray &val) const
+{
+    m_descriptorInterface->asyncCall("WriteValue", val, QVariantMap());
+}
+

--- a/qbledescriptor.cpp
+++ b/qbledescriptor.cpp
@@ -5,10 +5,21 @@ QBLEDescriptor::QBLEDescriptor(const QString &path, QObject *parent) : QObject(p
     m_descriptorInterface = new QDBusInterface("org.bluez", path, "org.bluez.GattDescriptor1", QDBusConnection::systemBus());
     m_uuid = m_descriptorInterface->property("UUID").toString();
 
-//    QStringList argumentMatch;
-//    argumentMatch << "org.bluez.GattDescriptor1";
-//    QDBusConnection::systemBus().connect("org.bluez", path, "org.freedesktop.DBus.Properties","PropertiesChanged", argumentMatch, QString(),
-//                            this, SLOT(onPropertiesChanged(QString, QVariantMap, QStringList)));
+    QStringList argumentMatch;
+    argumentMatch << "org.bluez.GattDescriptor1";
+    QDBusConnection::systemBus().connect("org.bluez", path, "org.freedesktop.DBus.Properties","PropertiesChanged", argumentMatch, QString(),
+                            this, SLOT(onPropertiesChanged(QString, QVariantMap, QStringList)));
+}
+
+void QBLEDescriptor::onPropertiesChanged(const QString &interface, const QVariantMap &map, const QStringList &list)
+{
+    Q_UNUSED(interface);
+    Q_UNUSED(list);
+    //qDebug() << "descriptor property changed" << interface << map;
+
+    if (map.contains("Value")) {
+        emit descriptorChanged(m_uuid, map["Value"].toByteArray());
+    }
 }
 
 void QBLEDescriptor::writeValue(const QByteArray &val) const
@@ -21,3 +32,45 @@ void QBLEDescriptor::writeAsync(const QByteArray &val) const
     m_descriptorInterface->asyncCall("WriteValue", val, QVariantMap());
 }
 
+void QBLEDescriptor::readAsync()
+{
+    QDBusPendingCall async = m_descriptorInterface->asyncCall("ReadValue", QVariantMap());
+    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(async, this);
+
+    QObject::connect(watcher, SIGNAL(finished(QDBusPendingCallWatcher*)),
+                     this, SLOT(readFinished(QDBusPendingCallWatcher*)));
+}
+
+void QBLEDescriptor::readFinished(QDBusPendingCallWatcher *call)
+{
+    QDBusPendingReply<QByteArray> reply = *call;
+    if (reply.isError()) {
+        qDebug() << "QBLEdescriptor::readFinished:" << reply.error().message();
+    } else {
+        m_value = reply.value();
+        emit descriptorRead(m_uuid, m_value);
+    }
+    call->deleteLater();
+}
+
+void QBLEDescriptor::startNotify() const
+{
+    m_descriptorInterface->call("StartNotify");
+}
+
+void QBLEDescriptor::stopNotify() const
+{
+    m_descriptorInterface->call("StopNotify");
+}
+
+QByteArray QBLEDescriptor::value() const
+{
+    return m_value;
+}
+
+QByteArray QBLEDescriptor::readValue() const
+{
+    QDBusReply<QByteArray> reply = m_descriptorInterface->call("ReadValue", QVariantMap());
+    //qDebug() << reply.error().message();
+    return reply.value();
+}

--- a/qbledescriptor.h
+++ b/qbledescriptor.h
@@ -13,16 +13,32 @@ public:
 
     void writeValue(const QByteArray &val) const;
     void writeAsync(const QByteArray &val) const;
+    QByteArray readValue() const;
+    void readAsync();
+    QByteArray value() const; //Returns last buffered value without a read
+
+    void startNotify() const;
+    void stopNotify() const;
+
+    Q_SIGNAL void descriptorChanged(const QString &characterisitc, const QByteArray &value);
+    Q_SIGNAL void descriptorRead(const QString &characterisitc, const QByteArray &value);
+
 
 private:
 
     QDBusInterface *m_descriptorInterface;
+
+    Q_SLOT void onPropertiesChanged(const QString &interface, const QVariantMap &map, const QStringList &list);
+    Q_SLOT void readFinished(QDBusPendingCallWatcher *call);
+
 
     // https://doc.qt.io/qt-6/qbluetoothuuid.html#DescriptorType-enum
     // for example
     //   QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration is 0x2902
     //   but UUID is "00002902-0000-1000-8000-00805f9b34fb"
     QString m_uuid;
+
+    QByteArray m_value; //buffered value;
 
 };
 

--- a/qbledescriptor.h
+++ b/qbledescriptor.h
@@ -1,0 +1,29 @@
+#ifndef QBLEDESCRIPTOR_H
+#define QBLEDESCRIPTOR_H
+
+#include <QObject>
+#include <QVariantMap>
+#include <QtDBus>
+
+class QBLEDescriptor : public QObject
+{
+    Q_OBJECT
+public:
+    explicit QBLEDescriptor(const QString &path, QObject *parent = nullptr);
+
+    void writeValue(const QByteArray &val) const;
+    void writeAsync(const QByteArray &val) const;
+
+private:
+
+    QDBusInterface *m_descriptorInterface;
+
+    // https://doc.qt.io/qt-6/qbluetoothuuid.html#DescriptorType-enum
+    // for example
+    //   QBluetoothUuid::DescriptorType::ClientCharacteristicConfiguration is 0x2902
+    //   but UUID is "00002902-0000-1000-8000-00805f9b34fb"
+    QString m_uuid;
+
+};
+
+#endif // QBLEDESCRIPTOR_H

--- a/qbleservice.cpp
+++ b/qbleservice.cpp
@@ -88,6 +88,26 @@ void QBLEService::writeAsync(const QString &c, const QByteArray &value)
     }
 }
 
+void QBLEService::writeDescriptorAsync(const QString &c, const QString &d, const QByteArray &value)
+{
+    qDebug() << Q_FUNC_INFO << c << d << value;
+
+    QBLECharacteristic *ch = characteristic(c);
+
+    if (!ch) {
+        qWarning() << "Unable to get characteristic";
+    }
+
+    QBLEDescriptor *desc = ch->descriptor(d);
+
+    if (!desc) {
+        qWarning() << "Unable to get descriptor";
+    }
+
+    desc->writeAsync(value);
+}
+
+
 QByteArray QBLEService::readValue(const QString &c)
 {
     qDebug() << "Reading from " << c;
@@ -112,8 +132,6 @@ void QBLEService::introspect()
 
     QDomNodeList nodes = doc.elementsByTagName("node");
 
-    qDebug() << nodes.count() << "nodes";
-
     for (int x = 0; x < nodes.count(); x++)
     {
         QDomElement node = nodes.at(x).toElement();
@@ -131,7 +149,7 @@ void QBLEService::introspect()
         connect(c, &QBLECharacteristic::characteristicRead, this, &QBLEService::characteristicReadInt);
     }
 
-    qDebug() << "Introspect:characteristics:" << m_characteristicMap.keys();
+    qDebug() << Q_FUNC_INFO << "characteristics" << m_characteristicMap.keys();
 }
 
 void QBLEService::onPropertiesChanged(const QString &interface, const QVariantMap &map, const QStringList &list)

--- a/qbleservice.cpp
+++ b/qbleservice.cpp
@@ -96,12 +96,14 @@ void QBLEService::writeDescriptorAsync(const QString &c, const QString &d, const
 
     if (!ch) {
         qWarning() << "Unable to get characteristic";
+        return;
     }
 
     QBLEDescriptor *desc = ch->descriptor(d);
 
     if (!desc) {
         qWarning() << "Unable to get descriptor";
+        return;
     }
 
     desc->writeAsync(value);

--- a/qbleservice.h
+++ b/qbleservice.h
@@ -31,6 +31,8 @@ public:
     void writeValue(const QString &characteristic, const QByteArray &value);
     void writeAsync(const QString &characteristic, const QByteArray &value);
 
+    void writeDescriptorAsync(const QString &characteristic, const QString &descriptor, const QByteArray &value);
+
     QByteArray readValue(const QString &characteristic);
     void readAsync(const QString &characteristic) const;
     void enableNotification(const QString &c);


### PR DESCRIPTION
Descriptors are needed to make screenshots on AsteroidOS working - https://github.com/piggz/harbour-amazfish/pull/320

For each characteristics can be available set of descriptors. I decided to add introspect() method into characteristics constructor to enumerate all available descriptors. 


Example of use is:
```
    writeDescriptorAsync("00006002-0000-0000-0000-00a57e401d05", "00002902-0000-1000-8000-00805f9b34fb", QByteArray::fromHex("0100"));
```
00006002-0000-0000-0000-00a57e401d05 is Content Characteristics from https://wiki.asteroidos.org/index.php/BLE_profiles#Screenshot_Profile

00002902-0000-1000-8000-00805f9b34fb is Client Characteristic Configuration 

