### PR TITLE
Expose alias and address of adapter

### DIFF
--- a/adaptermodel.cpp
+++ b/adaptermodel.cpp
@@ -24,6 +24,8 @@ AdapterModel::AdapterModel()
             if (iface == QStringLiteral("org.bluez.Adapter1")) {
                m_devices << path.path();
                m_deviceNames << ifaceList.value(iface).value(QStringLiteral("Name")).toString();
+               m_deviceAliases << ifaceList.value(iface).value(QStringLiteral("Alias")).toString();
+               m_deviceAddresses << ifaceList.value(iface).value(QStringLiteral("Address")).toString();
             }
         }
     }
@@ -41,6 +43,10 @@ QVariant AdapterModel::data(const QModelIndex &index, int role) const
             return m_devices.at(index.row());
         } else if (role == AdapterName) {
             return m_deviceNames.at(index.row());
+        } else if (role == AdapterAlias) {
+            return m_deviceAliases.at(index.row());
+        } else if (role == AdapterAddress) {
+            return m_deviceAddresses.at(index.row());
         }
     }
     return QVariant();
@@ -51,6 +57,8 @@ QHash<int, QByteArray> AdapterModel::roleNames() const
     QHash<int, QByteArray> names;
     names[AdapterPath] = "path";
     names[AdapterName] = "name";
+    names[AdapterAlias] = "alias";
+    names[AdapterAddress] = "address";
     names[ItemText] = "itemText";
 
     return names;
@@ -65,6 +73,8 @@ QVariantMap AdapterModel::get(int row) const {
     data["path"] = m_devices.at(row);
     data["itemText"] = data["path"];
     data["name"] = m_deviceNames.at(row);
+    data["alias"] = m_deviceAliases.at(row);
+    data["address"] = m_deviceAddresses.at(row);
 
     return data;
 }

--- a/adaptermodel.h
+++ b/adaptermodel.h
@@ -12,6 +12,8 @@ public:
     enum Roles {
         AdapterPath = Qt::UserRole + 1,
         AdapterName,
+        AdapterAlias,
+        AdapterAddress,
         ItemText
     };
 
@@ -25,6 +27,8 @@ private:
      QDBusInterface *m_objectManager = nullptr;
      QStringList m_devices;
      QStringList m_deviceNames;
+     QStringList m_deviceAliases;
+     QStringList m_deviceAddresses;
 
 };
 


### PR DESCRIPTION
I am still uncertain about which interface is actually used.

With following change in /qml/pages/Settings-app.qml can I get more details in ui:
```
            Component.onCompleted: {
                for (var i = 0; i < adapters.rowCount(); i++) {
                    var item = adapters.get(i)
                    console.log(JSON.stringify(item))
                    if (item.path == AmazfishConfig.localAdapter) {
                        cboLocalAdapter.currentIndex = i;
                        return
                    }
                }
            }
```

And output looks like this:
```
[20241117 19:10:27.431 CET D] qrc:/qml/pages/Settings-app.qml:32 - {"address":"E0:0A:F6:74:55:50","alias":"jmlich-thinkpad-builtin","itemText":"/org/bluez/hci0","name":"jmlich-thinkpad","path":"/org/bluez/hci0"}
[20241117 19:10:27.431 CET D] qrc:/qml/pages/Settings-app.qml:32 - {"address":"00:1A:7D:DA:71:07","alias":"jmlich-thinkpad-dongle","itemText":"/org/bluez/hci1","name":"jmlich-thinkpad #2","path":"/org/bluez/hci1"}
```