### PR TITLE
Refactor away the concept of 'operations' in QBle.

### DIFF
--- a/qbledevice.cpp
+++ b/qbledevice.cpp
@@ -67,11 +67,7 @@ QVariant QBLEDevice::deviceProperty(const char *name) const
     return QVariant();
 }
 
-bool QBLEDevice::operationRunning()
+QMap<QString, QBLEService *> QBLEDevice::services()
 {
-    bool running = false;
-    foreach(QBLEService* service, m_serviceMap) {
-        running |= service->operationRunning();
-    }
-    return running;
+    return m_serviceMap;
 }

--- a/qbledevice.h
+++ b/qbledevice.h
@@ -24,9 +24,6 @@ public:
     QString devicePath() const;
 
     Q_SIGNAL void propertiesChanged(const QString &interface, const QVariantMap &map, const QStringList &list);
-    Q_SIGNAL void operationRunningChanged();
-
-    Q_INVOKABLE bool operationRunning();
 
 protected:
     Q_SIGNAL void servicesResolved();
@@ -34,6 +31,7 @@ protected:
     void addService(const QString &uuid, QBLEService *service);
     QVariant deviceProperty(const char *name) const;
 
+    QMap<QString, QBLEService*> services();
 private:
     QString m_devicePath;
     QMap<QString, QBLEService*> m_serviceMap;

--- a/qbleservice.cpp
+++ b/qbleservice.cpp
@@ -176,8 +176,3 @@ void QBLEService::readAsync(const QString &c) const
         qDebug() << "Unable to get characteristic";
     }
 }
-
-bool QBLEService::operationRunning()
-{
-    return false;
-}

--- a/qbleservice.h
+++ b/qbleservice.h
@@ -39,8 +39,6 @@ public:
     void disableNotification(const QString &c);
 
     Q_SIGNAL void message(const QString &text);
-    Q_INVOKABLE virtual bool operationRunning();
-    Q_SIGNAL void operationRunningChanged();
 
 protected:
     Q_SIGNAL void propertiesChanged(QString, QVariantMap, QStringList);


### PR DESCRIPTION
This is now moved into Amazish, as it was a bit of a hack to be in qble, and didnt really make any sense.

Added a protected method to allow a subclass of QBLEDevice access to the service list.