### PR TITLE
toHex(':') is not compatible with SFOS's Qt

### DIFF
--- a/qblecharacteristic.cpp
+++ b/qblecharacteristic.cpp
@@ -29,7 +29,7 @@ void QBLECharacteristic::onPropertiesChanged(const QString &interface, const QVa
 
 void QBLECharacteristic::writeValue(const QByteArray &val) const
 {
-    qDebug() << Q_FUNC_INFO << val.toHex(':');
+    qDebug() << Q_FUNC_INFO << val.toHex();
     m_characteristicInterface->call("WriteValue", val, QVariantMap());
 }
 


### PR DESCRIPTION
```
/home/mersdk/build/qble/qblecharacteristic.cpp:32:45: error: no matching function for call to 'QByteArray::toHex(char) const'
   32 |     qDebug() << Q_FUNC_INFO << val.toHex(':');
```

![image](https://github.com/user-attachments/assets/69faebcb-237c-4f5d-a5f6-c9559d3cc363)

in https://github.com/piggz/harbour-amazfish/actions/runs/14628061755/job/41044312512