### PR TITLE
Add error handling for failed dbus calls.

### DIFF
--- a/qbledevice.cpp
+++ b/qbledevice.cpp
@@ -22,21 +22,54 @@ void QBLEDevice::pair()
 {
     qDebug() << "QBLEDevice::pair";
 
-    m_deviceInterface->asyncCall("Pair");
+    QDBusPendingCall pcall = m_deviceInterface->asyncCall("Pair");
+
+    auto watcher = new QDBusPendingCallWatcher(pcall, this);
+    QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this,
+                     [&](QDBusPendingCallWatcher *w) {
+        QDBusPendingReply<void> reply(*w);
+        qDebug() << reply.error().message();
+        if (reply.error().type() != QDBusError::NoError) {
+            Q_EMIT error(reply.error().message());
+        }
+        w->deleteLater();
+    });
 }
 
 void QBLEDevice::connectToDevice()
 {
     qDebug() << "QBLEDevice::connectToDevice";
 
-    m_deviceInterface->asyncCall("Connect");
+    QDBusPendingCall pcall = m_deviceInterface->asyncCall("Connect");
+
+    auto watcher = new QDBusPendingCallWatcher(pcall, this);
+    QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this,
+                     [&](QDBusPendingCallWatcher *w) {
+        QDBusPendingReply<void> reply(*w);
+        qDebug() << reply.error().message();
+        if (reply.error().type() != QDBusError::NoError) {
+            Q_EMIT error(reply.error().message());
+        }
+        w->deleteLater();
+    });
 }
 
 void QBLEDevice::disconnectFromDevice()
 {
     qDebug() << "QBLEDevice::disconnectFromDevice";
 
-    m_deviceInterface->call("Disconnect");
+    QDBusPendingCall pcall = m_deviceInterface->asyncCall("Disconnect");
+
+    auto watcher = new QDBusPendingCallWatcher(pcall, this);
+        QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this,
+                         [&](QDBusPendingCallWatcher *w) {
+            QDBusPendingReply<void> reply(*w);
+            qDebug() << reply.error().message();
+            if (reply.error().type() != QDBusError::NoError) {
+                Q_EMIT error(reply.error().message());
+            }
+            w->deleteLater();
+        });
 }
 
 QBLEService* QBLEDevice::service(const QString &uuid) const

--- a/qbledevice.cpp
+++ b/qbledevice.cpp
@@ -28,8 +28,8 @@ void QBLEDevice::pair()
     QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this,
                      [&](QDBusPendingCallWatcher *w) {
         QDBusPendingReply<void> reply(*w);
-        qDebug() << reply.error().message();
         if (reply.error().type() != QDBusError::NoError) {
+            qDebug() << reply.error().message();
             Q_EMIT error(reply.error().message());
         }
         w->deleteLater();
@@ -46,8 +46,8 @@ void QBLEDevice::connectToDevice()
     QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this,
                      [&](QDBusPendingCallWatcher *w) {
         QDBusPendingReply<void> reply(*w);
-        qDebug() << reply.error().message();
         if (reply.error().type() != QDBusError::NoError) {
+            qDebug() << reply.error().message();
             Q_EMIT error(reply.error().message());
         }
         w->deleteLater();
@@ -64,8 +64,8 @@ void QBLEDevice::disconnectFromDevice()
         QObject::connect(watcher, &QDBusPendingCallWatcher::finished, this,
                          [&](QDBusPendingCallWatcher *w) {
             QDBusPendingReply<void> reply(*w);
-            qDebug() << reply.error().message();
             if (reply.error().type() != QDBusError::NoError) {
+                qDebug() << reply.error().message();
                 Q_EMIT error(reply.error().message());
             }
             w->deleteLater();

--- a/qbledevice.h
+++ b/qbledevice.h
@@ -24,6 +24,7 @@ public:
     QString devicePath() const;
 
     Q_SIGNAL void propertiesChanged(const QString &interface, const QVariantMap &map, const QStringList &list);
+    Q_SIGNAL void error(const QString &message);
 
 protected:
     Q_SIGNAL void servicesResolved();


### PR DESCRIPTION
Currently just emits an error to the calling application for it to decide what to do.